### PR TITLE
refactor: create lib/bootstrap.sh, convert 5 scripts

### DIFF
--- a/scripts/lib/bootstrap.sh
+++ b/scripts/lib/bootstrap.sh
@@ -1,9 +1,111 @@
 #!/usr/bin/env bash
 # ╔═══════════════════════════════════════════════════════════════════════════╗
-# ║  shipwright bootstrap — Cold-start initialization for optimization data  ║
-# ║  Creates sensible defaults when no historical data exists (new installs)  ║
+# ║  shipwright bootstrap — Boilerplate consolidation + initialization       ║
+# ║                                                                          ║
+# ║  Part 1: Boilerplate elimination (SCRIPT_DIR, ERR trap, library loading) ║
+# ║  Part 2: Cold-start initialization (optimization, memory defaults)       ║
+# ║  Part 3: Helper functions (show_help_header for standard boxed headers) ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 
+# ─── Module Guard (prevent double-sourcing) ─────────────────────────────
+[[ -n "${_SW_BOOTSTRAP_LOADED:-}" ]] && return 0
+_SW_BOOTSTRAP_LOADED=1
+
+# ─── Part 1: Boilerplate Elimination ───────────────────────────────────
+#
+# SCRIPT_DIR Resolution: Caller's BASH_SOURCE[0] is expected to be in scripts/
+# We derive SCRIPT_DIR from the call stack, skipping lib/ sources.
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    # Find the first non-lib caller (skip lib/bootstrap.sh itself)
+    for _src in "${BASH_SOURCE[@]}"; do
+        if [[ "$_src" != *"/lib/"* && "$_src" != "$BASH_SOURCE" ]]; then
+            SCRIPT_DIR="$(cd "$(dirname "$_src")" && pwd)"
+            break
+        fi
+    done
+    # Fallback if all sources are in lib/
+    if [[ -z "${SCRIPT_DIR:-}" ]]; then
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        SCRIPT_DIR="${SCRIPT_DIR%/lib}"  # strip /lib suffix if present
+    fi
+fi
+export SCRIPT_DIR
+
+# Set up ERR trap (if not already set)
+if [[ "$(trap -p ERR)" == "" ]]; then
+    trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
+fi
+
+# Source lib/compat.sh (cross-platform compatibility)
+# shellcheck source=./compat.sh
+if [[ -f "$SCRIPT_DIR/lib/compat.sh" ]]; then
+    source "$SCRIPT_DIR/lib/compat.sh"
+fi
+
+# Source lib/helpers.sh (colors, output, timestamps)
+# shellcheck source=./helpers.sh
+if [[ -f "$SCRIPT_DIR/lib/helpers.sh" ]]; then
+    source "$SCRIPT_DIR/lib/helpers.sh"
+fi
+
+# Fallbacks (when helpers not loaded, e.g. test env)
+[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
+[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
+[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
+[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
+
+# Color fallbacks (when NO_COLOR is set or lib/helpers.sh not sourced)
+if [[ -z "${CYAN:-}" ]]; then
+    CYAN='\033[38;2;0;212;255m'
+    PURPLE='\033[38;2;124;58;237m'
+    BLUE='\033[38;2;0;102;255m'
+    GREEN='\033[38;2;74;222;128m'
+    YELLOW='\033[38;2;250;204;21m'
+    RED='\033[38;2;248;113;113m'
+    DIM='\033[2m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+fi
+
+if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
+    now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+    now_epoch() { date +%s; }
+fi
+
+if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
+    emit_event() {
+        local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
+        # shellcheck disable=SC2155
+        local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
+        while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
+        echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
+    }
+fi
+
+# ─── Part 3: Standard Header Helper ────────────────────────────────────
+#
+# show_help_header — Prints a standard boxed header with script name, description, and version.
+# Usage:
+#   show_help_header "Script Name" "Optional description line"
+show_help_header() {
+    local name="$1"
+    local desc="${2:-}"
+
+    echo ""
+    if [[ -n "$desc" ]]; then
+        echo -e "${CYAN}${BOLD}  ${name}${RESET}  ${DIM}v${VERSION:-unknown}${RESET}"
+        echo -e "${DIM}  $(printf '%0.s═' $(seq 1 42))${RESET}"
+        echo ""
+        echo -e "  ${desc}"
+    else
+        echo -e "${CYAN}${BOLD}  ${name}${RESET}  ${DIM}v${VERSION:-unknown}${RESET}"
+        echo -e "${DIM}  $(printf '%0.s═' $(seq 1 42))${RESET}"
+    fi
+    echo ""
+}
+
+# ─── Part 2: Cold-Start Initialization ────────────────────────────────
+#
 # bootstrap_optimization — create default iteration model, template weights, model routing
 bootstrap_optimization() {
     local opt_dir="$HOME/.shipwright/optimization"

--- a/scripts/sw-cleanup.sh
+++ b/scripts/sw-cleanup.sh
@@ -8,37 +8,13 @@
 # shellcheck disable=SC2034
 VERSION="3.2.4"
 set -euo pipefail
-trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/bootstrap.sh"
 
-# Canonical helpers (colors, output, events)
-# shellcheck source=lib/helpers.sh
-[[ -f "$SCRIPT_DIR/lib/helpers.sh" ]] && source "$SCRIPT_DIR/lib/helpers.sh"
-# shellcheck source=lib/compat.sh
-[[ -f "$SCRIPT_DIR/lib/compat.sh" ]] && source "$SCRIPT_DIR/lib/compat.sh"
 [[ -f "$SCRIPT_DIR/lib/config.sh" ]] && source "$SCRIPT_DIR/lib/config.sh"
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-
-# Fallbacks when helpers not loaded (e.g. test env with overridden SCRIPT_DIR)
-[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
-[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
-[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
-[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
-if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
-  now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-  now_epoch() { date +%s; }
-fi
-if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
-  emit_event() {
-    local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
-    # shellcheck disable=SC2155
-    local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
-    while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
-    echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
-  }
-fi
 # ─── Parse Args ──────────────────────────────────────────────────────────────
 
 FORCE=false

--- a/scripts/sw-heartbeat-test.sh
+++ b/scripts/sw-heartbeat-test.sh
@@ -30,6 +30,9 @@ setup_env() {
     cp "$SCRIPT_DIR/sw-heartbeat.sh" "$TEST_TEMP_DIR/scripts/"
     cp "$SCRIPT_DIR/sw-checkpoint.sh" "$TEST_TEMP_DIR/scripts/"
 
+    # Copy lib/ directory for bootstrap.sh and dependencies
+    cp -r "$SCRIPT_DIR/lib" "$TEST_TEMP_DIR/scripts/"
+
     # Mock git for checkpoint tests
     mkdir -p "$TEST_TEMP_DIR/bin"
     cat > "$TEST_TEMP_DIR/bin/git" <<'EOF'

--- a/scripts/sw-heartbeat.sh
+++ b/scripts/sw-heartbeat.sh
@@ -4,40 +4,14 @@
 # ║  Write · Check · List · Clear heartbeats for autonomous agents          ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 set -euo pipefail
-trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
 
 VERSION="3.2.4"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# ─── Cross-platform compatibility ──────────────────────────────────────────
-# shellcheck source=lib/compat.sh
-[[ -f "$SCRIPT_DIR/lib/compat.sh" ]] && source "$SCRIPT_DIR/lib/compat.sh"
-
-# Canonical helpers (colors, output, events)
-# shellcheck source=lib/helpers.sh
-[[ -f "$SCRIPT_DIR/lib/helpers.sh" ]] && source "$SCRIPT_DIR/lib/helpers.sh"
+# shellcheck source=lib/bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/bootstrap.sh"
 
 # SQLite persistence (DB as primary read path)
 # shellcheck source=sw-db.sh
 [[ -f "$SCRIPT_DIR/sw-db.sh" ]] && source "$SCRIPT_DIR/sw-db.sh"
-# Fallbacks when helpers not loaded (e.g. test env with overridden SCRIPT_DIR)
-[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
-[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
-[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
-[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
-if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
-  now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-  now_epoch() { date +%s; }
-fi
-if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
-  emit_event() {
-    local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
-    # shellcheck disable=SC2155
-    local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
-    while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
-    echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
-  }
-fi
 # ─── Constants ──────────────────────────────────────────────────────────────
 HEARTBEAT_DIR="$HOME/.shipwright/heartbeats"
 

--- a/scripts/sw-ps-test.sh
+++ b/scripts/sw-ps-test.sh
@@ -86,10 +86,10 @@ else
     assert_fail "set -euo pipefail present"
 fi
 
-if grep -q "trap.*ERR" "$SRC"; then
-    assert_pass "ERR trap present"
+if grep -q "bootstrap.sh" "$SRC" || grep -q "trap.*ERR" "$SRC"; then
+    assert_pass "ERR trap present (via bootstrap or inline)"
 else
-    assert_fail "ERR trap present"
+    assert_fail "ERR trap present (via bootstrap or inline)"
 fi
 
 if grep -q '^VERSION=' "$SRC"; then

--- a/scripts/sw-ps.sh
+++ b/scripts/sw-ps.sh
@@ -8,31 +8,9 @@
 # shellcheck disable=SC2034
 VERSION="3.2.4"
 set -euo pipefail
-trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Canonical helpers (colors, output, events)
-# shellcheck source=lib/helpers.sh
-[[ -f "$SCRIPT_DIR/lib/helpers.sh" ]] && source "$SCRIPT_DIR/lib/helpers.sh"
-# Fallbacks when helpers not loaded (e.g. test env with overridden SCRIPT_DIR)
-[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
-[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
-[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
-[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
-if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
-  now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-  now_epoch() { date +%s; }
-fi
-if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
-  emit_event() {
-    local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
-    # shellcheck disable=SC2155
-    local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
-    while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
-    echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
-  }
-fi
+# shellcheck source=lib/bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/bootstrap.sh"
 # ─── Format idle time ───────────────────────────────────────────────────────
 format_idle() {
     local seconds="$1"

--- a/scripts/sw-reaper-test.sh
+++ b/scripts/sw-reaper-test.sh
@@ -104,10 +104,10 @@ else
     assert_fail "set -euo pipefail present"
 fi
 
-if grep -q "trap.*ERR" "$SCRIPT_DIR/sw-reaper.sh"; then
-    assert_pass "ERR trap present"
+if grep -q "bootstrap.sh" "$SCRIPT_DIR/sw-reaper.sh" || grep -q "trap.*ERR" "$SCRIPT_DIR/sw-reaper.sh"; then
+    assert_pass "ERR trap present (via bootstrap or inline)"
 else
-    assert_fail "ERR trap present"
+    assert_fail "ERR trap present (via bootstrap or inline)"
 fi
 
 echo ""

--- a/scripts/sw-reaper.sh
+++ b/scripts/sw-reaper.sh
@@ -14,31 +14,9 @@
 # shellcheck disable=SC2034
 VERSION="3.2.4"
 set -euo pipefail
-trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Canonical helpers (colors, output, events)
-# shellcheck source=lib/helpers.sh
-[[ -f "$SCRIPT_DIR/lib/helpers.sh" ]] && source "$SCRIPT_DIR/lib/helpers.sh"
-# Fallbacks when helpers not loaded (e.g. test env with overridden SCRIPT_DIR)
-[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
-[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
-[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
-[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
-if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
-  now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-  now_epoch() { date +%s; }
-fi
-if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
-  emit_event() {
-    local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
-    # shellcheck disable=SC2155
-    local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
-    while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
-    echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
-  }
-fi
+# shellcheck source=lib/bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/bootstrap.sh"
 # ─── Defaults ──────────────────────────────────────────────────────────────
 WATCH=false
 DRY_RUN=false

--- a/scripts/sw-templates-test.sh
+++ b/scripts/sw-templates-test.sh
@@ -91,10 +91,10 @@ else
     assert_fail "set -euo pipefail present"
 fi
 
-if grep -q "trap.*ERR" "$SCRIPT_DIR/sw-templates.sh"; then
-    assert_pass "ERR trap present"
+if grep -q "bootstrap.sh" "$SCRIPT_DIR/sw-templates.sh" || grep -q "trap.*ERR" "$SCRIPT_DIR/sw-templates.sh"; then
+    assert_pass "ERR trap present (via bootstrap or inline)"
 else
-    assert_fail "ERR trap present"
+    assert_fail "ERR trap present (via bootstrap or inline)"
 fi
 
 echo ""

--- a/scripts/sw-templates.sh
+++ b/scripts/sw-templates.sh
@@ -8,35 +8,9 @@
 # shellcheck disable=SC2034
 VERSION="3.2.4"
 set -euo pipefail
-trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# ─── Cross-platform compatibility ──────────────────────────────────────────
-# shellcheck source=lib/compat.sh
-[[ -f "$SCRIPT_DIR/lib/compat.sh" ]] && source "$SCRIPT_DIR/lib/compat.sh"
-
-# Canonical helpers (colors, output, events)
-# shellcheck source=lib/helpers.sh
-[[ -f "$SCRIPT_DIR/lib/helpers.sh" ]] && source "$SCRIPT_DIR/lib/helpers.sh"
-# Fallbacks when helpers not loaded (e.g. test env with overridden SCRIPT_DIR)
-[[ "$(type -t info 2>/dev/null)" == "function" ]]    || info()    { echo -e "\033[38;2;0;212;255m\033[1m▸\033[0m $*"; }
-[[ "$(type -t success 2>/dev/null)" == "function" ]] || success() { echo -e "\033[38;2;74;222;128m\033[1m✓\033[0m $*"; }
-[[ "$(type -t warn 2>/dev/null)" == "function" ]]    || warn()    { echo -e "\033[38;2;250;204;21m\033[1m⚠\033[0m $*"; }
-[[ "$(type -t error 2>/dev/null)" == "function" ]]   || error()   { echo -e "\033[38;2;248;113;113m\033[1m✗\033[0m $*" >&2; }
-if [[ "$(type -t now_iso 2>/dev/null)" != "function" ]]; then
-  now_iso()   { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
-  now_epoch() { date +%s; }
-fi
-if [[ "$(type -t emit_event 2>/dev/null)" != "function" ]]; then
-  emit_event() {
-    local event_type="$1"; shift; mkdir -p "${HOME}/.shipwright"
-    # shellcheck disable=SC2155
-    local payload="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"type\":\"$event_type\""
-    while [[ $# -gt 0 ]]; do local key="${1%%=*}" val="${1#*=}"; payload="${payload},\"${key}\":\"${val}\""; shift; done
-    echo "${payload}}" >> "${HOME}/.shipwright/events.jsonl"
-  }
-fi
+# shellcheck source=lib/bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/bootstrap.sh"
 # ─── Template Discovery ─────────────────────────────────────────────────────
 REPO_TEMPLATES_DIR="$(cd "$SCRIPT_DIR/../tmux/templates" 2>/dev/null && pwd)" || REPO_TEMPLATES_DIR=""
 USER_TEMPLATES_DIR="${HOME}/.shipwright/templates"


### PR DESCRIPTION
## Summary
- Created `lib/bootstrap.sh` consolidating boilerplate from 76+ scripts: SCRIPT_DIR resolution, ERR trap, lib sourcing, colors, output helpers, timestamps, event logging, show_help_header()
- Converted 5 proof-of-concept scripts with 78-83% boilerplate reduction:
  - `sw-heartbeat.sh`: 41→9 lines boilerplate
  - `sw-cleanup.sh`: 41→9 lines boilerplate
  - `sw-reaper.sh`: 41→7 lines boilerplate
  - `sw-ps.sh`: 35→7 lines boilerplate
  - `sw-templates.sh`: 39→7 lines boilerplate
- Pattern scales to 76 scripts, eliminating ~3,648 lines of duplicated boilerplate

## Test plan
- [x] sw-heartbeat-test: 17/17 passed
- [x] sw-cleanup-test: 24/24 passed
- [x] sw-reaper-test: all checks passed
- [x] sw-ps-test: all checks passed
- [x] sw-templates-test: all checks passed

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated internal initialization and helper utilities across build scripts for improved maintainability.
  * Updated test infrastructure to recognize refactored initialization mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->