### PR TITLE
fix: green CI — O(N²) dead-code scan, dependabot claude-review, model currency

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -233,12 +233,27 @@ All `claude` CLI invocations in the pipeline support these flags:
 
 Per-stage effort levels are config-driven via `daemon-config.json` `effort_levels` section. CLI `--effort` overrides config.
 
-| Stage                                  | Default Effort | Rationale                   |
-| -------------------------------------- | -------------- | --------------------------- |
-| intake, pr, merge                      | low            | Mechanical/formatting tasks |
-| build, test, deploy, validate, monitor | medium         | Standard development work   |
-| plan, design, review, compound_quality | high           | Complex reasoning required  |
-| spec_generation, spec_verification     | high           | Specification analysis      |
+Effort is spent **asymmetrically**. Coding and agentic work is where it pays
+off most, and refinement/review dominates agentic token cost — so `build`,
+`review`, and `compound_quality` get the deep setting, while mechanical stages
+stay cheap (lower effort there means fewer, more consolidated tool calls and
+less preamble, which is what you want from intake/pr/merge). One `xhigh` review
+pass is preferred over adding more review rounds.
+
+| Stage                            | Default Effort | Rationale                                  |
+| -------------------------------- | -------------- | ------------------------------------------ |
+| intake, pr, merge                | low            | Mechanical/formatting tasks                |
+| test, deploy, validate, monitor  | medium         | Standard development work                  |
+| plan, design                     | high           | Complex reasoning, not code authoring      |
+| spec_generation, spec_verification | high         | Specification analysis                     |
+| build                            | xhigh          | Agentic coding — the stage that writes code |
+| review, compound_quality         | xhigh          | One deep pass beats several cheaper rounds |
+
+`max` is deliberately not a default anywhere: it shows diminishing returns and
+can overthink. Reach for it per-run via `EFFORT_LEVEL_OVERRIDE` when
+correctness matters more than cost. The ladder is pinned by tests in
+`scripts/sw-lib-compat-test.sh`, which also assert every stage maps to a level
+the `claude` CLI actually accepts.
 
 Override globally via CLI: `--effort high` or via `daemon-config.json`:
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -616,10 +616,10 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-checkpoint.sh` | 605 | Save and restore agent state mid-stage |
 | `scripts/sw-ci.sh` | 589 | GitHub Actions CI/CD Orchestration |
 | `scripts/sw-cleanup.sh` | 350 | Clean up orphaned Claude team sessions & artifacts |
-| `scripts/sw-code-review.sh` | 697 | Clean Code & Architecture Analysis |
+| `scripts/sw-code-review.sh` | 699 | Clean Code & Architecture Analysis |
 | `scripts/sw-connect.sh` | 624 | Sync local state to team dashboard |
 | `scripts/sw-context.sh` | 600 | Context Engine for Pipeline Stages |
-| `scripts/sw-cost.sh` | 1056 | Token Usage & Cost Intelligence |
+| `scripts/sw-cost.sh` | 1070 | Token Usage & Cost Intelligence |
 | `scripts/sw-daemon.sh` | 1420 | Autonomous GitHub Issue Watcher |
 | `scripts/sw-dashboard.sh` | 510 | Fleet Command Dashboard |
 | `scripts/sw-db.sh` | 1939 | SQLite Persistence Layer |
@@ -646,7 +646,7 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-guild.sh` | 556 | Knowledge Guilds & Cross-Team Learning |
 | `scripts/sw-heartbeat.sh` | 316 | File-based agent heartbeat protocol |
 | `scripts/sw-hello.sh` | 67 | Hello World Command |
-| `scripts/sw-hygiene.sh` | 668 | Repository Organization & Cleanup |
+| `scripts/sw-hygiene.sh` | 724 | Repository Organization & Cleanup |
 | `scripts/sw-incident.sh` | 1132 | Autonomous Incident Detection & Response |
 | `scripts/sw-init.sh` | 871 | Complete setup for Shipwright + Shipwright |
 | `scripts/sw-instrument.sh` | 691 | Pipeline Instrumentation & Feedback Loops |
@@ -694,7 +694,7 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-swarm.sh` | 684 | Dynamic agent swarm management |
 | `scripts/sw-team-stages.sh` | 500 | Multi-agent execution with leader/specialist roles |
 | `scripts/sw-templates.sh` | 228 | Browse and inspect team templates |
-| `scripts/sw-test-all.sh` | 182 | Run every test suite, report the FULL result |
+| `scripts/sw-test-all.sh` | 199 | Run every test suite, report the FULL result |
 | `scripts/sw-testgen.sh` | 567 | Autonomous test generation and coverage maintenance |
 | `scripts/sw-tmux-pipeline.sh` | 538 | Spawn and manage pipelines in tmux windows |
 | `scripts/sw-tmux-role-color.sh` | 81 | Set pane border color by agent role |
@@ -768,7 +768,7 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-checkpoint-test.sh` | 341 | Validate checkpoint save/restore |
 | `scripts/sw-ci-test.sh` | 198 | GitHub Actions CI/CD orchestration tests |
 | `scripts/sw-cleanup-test.sh` | 168 | Clean up orphaned sessions & artifacts |
-| `scripts/sw-code-review-test.sh` | 173 | Clean code & architecture analysis tests |
+| `scripts/sw-code-review-test.sh` | 175 | Clean code & architecture analysis tests |
 | `scripts/sw-connect-test.sh` | 822 | Validate dashboard connection, heartbeat |
 | `scripts/sw-constitutional-test.sh` | 320 | Constitutional AI Test Suite |
 | `scripts/sw-context-budget-test.sh` | 335 | Context Window Budget Monitor tests |
@@ -816,13 +816,13 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-incident-test.sh` | 442 | Validate incident detection & response |
 | `scripts/sw-init-test.sh` | 654 | E2E validation of init/setup flow |
 | `scripts/sw-instrument-test.sh` | 172 | Pipeline instrumentation & feedback loops |
-| `scripts/sw-integration-claude-test.sh` | 71 | Budget-limited real Claude smoke |
+| `scripts/sw-integration-claude-test.sh` | 106 | Budget-limited real Claude smoke |
 | `scripts/sw-intelligence-test.sh` | 534 | Unit tests for intelligence core |
 | `scripts/sw-intent-analysis-test.sh` | 443 | Test suite for intent analysis module |
 | `scripts/sw-jira-test.sh` | 284 | Validate Jira ↔ GitHub bidirectional sync |
 | `scripts/sw-launchd-test.sh` | 899 | Validate service management on |
 | `scripts/sw-lib-audit-trail-test.sh` | 311 |  |
-| `scripts/sw-lib-compat-test.sh` | 297 | Unit tests for cross-platform helpers |
+| `scripts/sw-lib-compat-test.sh` | 357 | Unit tests for cross-platform helpers |
 | `scripts/sw-lib-compound-audit-test.sh` | 281 |  |
 | `scripts/sw-lib-daemon-dispatch-test.sh` | 421 | Unit tests for spawn/reap/queue |
 | `scripts/sw-lib-daemon-failure-test.sh` | 213 | Unit tests for failure handling |
@@ -851,7 +851,7 @@ All scripts are bash (except the dashboard server in TypeScript). Grouped by lay
 | `scripts/sw-oversight-test.sh` | 164 | Quality oversight board tests |
 | `scripts/sw-patrol-meta-test.sh` | 449 | Validate self-improvement patrol |
 | `scripts/sw-pipeline-composer-test.sh` | 632 | Test Suite |
-| `scripts/sw-pipeline-test.sh` | 1961 | E2E validation invoking the REAL pipeline |
+| `scripts/sw-pipeline-test.sh` | 1964 | E2E validation invoking the REAL pipeline |
 | `scripts/sw-pipeline-vitals-test.sh` | 226 | Validate pipeline health scoring |
 | `scripts/sw-pm-test.sh` | 225 | Autonomous PM Agent test suite |
 | `scripts/sw-policy-e2e-test.sh` | 290 | Verify config/policy.json is honored |

--- a/.github/workflows/auto-resolve-threads.yml
+++ b/.github/workflows/auto-resolve-threads.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Determine PR
         id: pr

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,20 +19,46 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+
+    # Dependabot and fork PRs run with a read-only token and NO access to repo
+    # secrets, so claude_code_oauth_token interpolates to an empty string and the
+    # action fails at the installation-token step ~12s in. That is what made this
+    # a permanently-red check on every dependabot PR (#583, #635, #636). Lockfile
+    # bumps do not need an AI review pass, so skip rather than paper over it.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
 
+    env:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
     steps:
+      # Mirrors the integration-claude job in test.yml: a missing credential is
+      # a skip, not a failure. Without this the job reports red on any PR where
+      # the secret is unset or expired, which is indistinguishable from a real
+      # review finding.
+      - name: Check for Claude credentials
+        run: |
+          if [[ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]]; then
+            echo "No CLAUDE_CODE_OAUTH_TOKEN available — skipping Claude review"
+            echo "SKIP_CLAUDE=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Checkout repository
+        if: env.SKIP_CLAUDE != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
+        if: env.SKIP_CLAUDE != 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Checkout repository
         if: env.SKIP_CLAUDE != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -19,14 +19,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y tmux jq
@@ -83,7 +83,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-artifacts
           path: |
@@ -101,7 +101,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Cleanup orphaned e2e-test resources
         run: |

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-test-artifacts-${{ matrix.os }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
@@ -21,7 +21,7 @@ jobs:
         run: bash scripts/build-release.sh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts
           path: dist/
@@ -30,10 +30,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-artifacts
           path: dist/
@@ -55,11 +55,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
@@ -71,7 +71,7 @@ jobs:
     needs: github-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
 

--- a/.github/workflows/review-remediation.yml
+++ b/.github/workflows/review-remediation.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/risk-policy-gate.yml
+++ b/.github/workflows/risk-policy-gate.yml
@@ -21,7 +21,7 @@ jobs:
       required_checks: ${{ steps.classify.outputs.required_checks }}
       docs_drift: ${{ steps.drift.outputs.drift_detected }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shipwright-docs.yml
+++ b/.github/workflows/shipwright-docs.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shipwright-optimize.yml
+++ b/.github/workflows/shipwright-optimize.yml
@@ -22,7 +22,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/shipwright-patrol.yml
+++ b/.github/workflows/shipwright-patrol.yml
@@ -22,7 +22,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Full history for doc staleness checks
 

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -76,7 +76,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Rate limit jitter
         run: |
@@ -356,7 +356,7 @@ jobs:
       NO_COLOR: "1"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -764,7 +764,7 @@ jobs:
 
       - name: Upload pipeline artifacts
         if: always() && steps.claim_check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pipeline-artifacts-${{ env.ISSUE_NUMBER }}
           path: |

--- a/.github/workflows/shipwright-platform-health.yml
+++ b/.github/workflows/shipwright-platform-health.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate policy.json
         run: |

--- a/.github/workflows/shipwright-regression.yml
+++ b/.github/workflows/shipwright-regression.yml
@@ -27,7 +27,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/shipwright-strategic.yml
+++ b/.github/workflows/shipwright-strategic.yml
@@ -25,7 +25,7 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shipwright-sweep.yml
+++ b/.github/workflows/shipwright-sweep.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Load sweep policy from config
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check version consistency
         run: bash scripts/check-version-consistency.sh
@@ -54,7 +54,7 @@ jobs:
             echo "SKIP_CLAUDE=true" >> "$GITHUB_ENV"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: env.SKIP_CLAUDE != 'true'
 
       - name: Install dependencies
@@ -77,7 +77,7 @@ jobs:
   integration-claude-skip:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run integration-claude without secrets (expect skip)
         run: |
           out=$(bash scripts/sw-integration-claude-test.sh 2>&1) || exit 1
@@ -88,12 +88,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci
@@ -104,7 +104,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install ShellCheck
         # Pinned, not apt: whatever version the runner image ships drifts from

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,11 @@ jobs:
         # applies a per-suite timeout — previously a single hung suite could
         # stall this job until the workflow-level limit killed it with no
         # indication of which suite was responsible.
+        # 25 lines of tail truncated the failing assertion for several suites,
+        # leaving CI showing that a suite failed but not which check. Only
+        # printed on failure, so a green run is unaffected.
+        env:
+          FAIL_LOG_LINES: 120
         run: |
           bash scripts/sw-test-all.sh --timeout 300
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,11 @@ jobs:
 
       - name: Install dependencies
         if: env.SKIP_CLAUDE != 'true'
-        run: sudo apt-get update && sudo apt-get install -y tmux jq
+        # bubblewrap + socat are the Claude CLI's sandbox dependencies. Without
+        # them it prints "Sandbox disabled: … bwrap not installed, socat not
+        # installed" and exits 1, which was this job's only failure once the
+        # exit-code reporting bug was fixed (it previously claimed "exit 0").
+        run: sudo apt-get update && sudo apt-get install -y tmux jq bubblewrap socat
 
       - name: Install Claude Code CLI
         if: env.SKIP_CLAUDE != 'true'
@@ -103,7 +107,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install ShellCheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+        # Pinned, not apt: whatever version the runner image ships drifts from
+        # what developers run locally, and shellcheck changes its findings
+        # between releases. apt's build reported SC2120 on functions that take
+        # optional `${1:-default}` arguments; 0.11.0 correctly does not. That
+        # skew is the classic "passes locally, fails only in CI".
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+        run: |
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJf - --strip-components=1 -C /usr/local/bin "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          shellcheck --version
 
       - name: Lint scripts
         # Warning severity is enforced, minus three codes that are structural to
@@ -113,9 +127,15 @@ jobs:
         #   SC1090 — "can't follow non-constant source": every lib load is
         #            "$SCRIPT_DIR/lib/x.sh" by design.
         #   SC2148 — "no shebang": lib files are sourced, never executed.
+        #   SC2119/SC2120 — "references arguments, but none are ever passed":
+        #            fires on functions with optional `${1:-default}` params,
+        #            which is a deliberate pattern here (gen_agent_id,
+        #            optimize_learn_risk_keywords). 0.11.0 no longer reports
+        #            these; the codes stay excluded so an older shellcheck
+        #            cannot resurrect them.
         # Everything else is a real finding and blocks. This gate had been failing
         # continuously since 2026-04-05 on 89 findings; the 15 genuine ones are
         # fixed (a real unbound-variable bug among them) and the gate now passes,
         # so it can actually block regressions instead of being ignored.
         run: |
-          shellcheck -x -S warning -e SC2034,SC1090,SC2148 scripts/sw scripts/sw-*.sh install.sh
+          shellcheck -x -S warning -e SC2034,SC1090,SC2148,SC2119,SC2120 scripts/sw scripts/sw-*.sh install.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,19 @@ jobs:
 
       - name: Run budget-limited Claude integration smoke
         if: env.SKIP_CLAUDE != 'true'
-        run: bash scripts/sw-integration-claude-test.sh
+        # The CLI resolves ANTHROPIC_API_KEY *before* CLAUDE_CODE_OAUTH_TOKEN,
+        # so exporting both lets a stale key shadow a working token — which is
+        # exactly what happened here: the job failed "Invalid API key" while
+        # claude-review, which uses the OAuth token directly, passed on the
+        # same commit. Setting the key to '' does not help; an empty value
+        # still wins its precedence slot and authenticates as an empty key. It
+        # has to be genuinely unset, so prefer the OAuth token when both exist
+        # and fall back to the key only when there is no token.
+        run: |
+          if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+            unset ANTHROPIC_API_KEY
+          fi
+          bash scripts/sw-integration-claude-test.sh
 
   # Validate integration-claude skip path when no secret (script must exit 0 and skip)
   integration-claude-skip:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: website/package-lock.json
 
@@ -39,7 +39,7 @@ jobs:
         working-directory: website
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -195,8 +195,28 @@ detect_test_framework() {
 # ─── Cross-platform file modification time (epoch) ────────────────────────
 # macOS/BSD: stat -f %m; Linux: stat -c '%Y'
 file_mtime() {
-    local file="$1"
-    stat -f %m "$file" 2>/dev/null || stat -c '%Y' "$file" 2>/dev/null || echo "0"
+    local file="$1" out
+
+    # `-f` means two different things: BSD/macOS reads it as the output FORMAT,
+    # GNU coreutils reads it as --file-system. So `stat -f %m FILE` on Linux
+    # does not fail cleanly — it prints filesystem information for FILE on
+    # stdout. The old `stat -f … || stat -c … || echo 0` chain therefore
+    # captured that text (possibly concatenated with the real answer), and
+    # callers got something that was not an epoch. Probe each dialect and
+    # accept the result only if it actually looks like one.
+    out=$(stat -c '%Y' "$file" 2>/dev/null) || out=""
+    if [[ "$out" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+
+    out=$(stat -f '%m' "$file" 2>/dev/null) || out=""
+    if [[ "$out" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$out"
+        return 0
+    fi
+
+    printf '0\n'
 }
 
 # ─── Timeout command (macOS may lack timeout; gtimeout from coreutils) ─────

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -389,15 +389,36 @@ _smart_effort() {
         fi
     fi
 
-    # 3. Intelligent defaults (same as before, but now overridable)
+    # 3. Intelligent defaults (overridable via config or EFFORT_LEVEL_OVERRIDE)
+    #
+    # Effort is spent ASYMMETRICALLY, not uniformly. Two things drive the shape:
+    #
+    #   - Coding and agentic work is where effort pays off most. `xhigh` is the
+    #     recommended setting for those and is what Claude Code itself defaults
+    #     to; `build` previously sat at `medium`, which underspent on the one
+    #     stage that writes the code.
+    #   - Refinement and review dominate agentic token cost, and a single
+    #     high-effort review pass beats several cheaper ones. So `review` and
+    #     `compound_quality` go to `xhigh` rather than adding more rounds.
+    #
+    # Mechanical stages stay at `low` deliberately — lower effort there means
+    # fewer, more consolidated tool calls and less preamble, which is what you
+    # want from intake/pr/merge. `max` is intentionally not a default anywhere:
+    # it shows diminishing returns and can overthink. Reach for it per-run via
+    # EFFORT_LEVEL_OVERRIDE when correctness matters more than cost.
+    #
+    # spec_generation/spec_verification are listed explicitly because they were
+    # falling through to the `medium` catch-all while the docs claimed `high`.
     case "$stage" in
-        intake)              echo "low" ;;
-        plan|design)         echo "high" ;;
-        build|test)          echo "medium" ;;
-        review|compound_quality) echo "high" ;;
-        pr|merge)            echo "low" ;;
+        intake)                  echo "low" ;;
+        plan|design)             echo "high" ;;
+        spec_generation|spec_verification) echo "high" ;;
+        build)                   echo "xhigh" ;;
+        test)                    echo "medium" ;;
+        review|compound_quality) echo "xhigh" ;;
+        pr|merge)                echo "low" ;;
         deploy|validate|monitor) echo "medium" ;;
-        *)                   echo "medium" ;;
+        *)                       echo "medium" ;;
     esac
 }
 

--- a/scripts/lib/intent-analysis.sh
+++ b/scripts/lib/intent-analysis.sh
@@ -299,6 +299,32 @@ ${arch_rules}
     echo "${plan_prompt}${injection}"
 }
 
+# Print the failure-mode section: its heading through the next TOP-LEVEL
+# heading, keeping any `###` subsections inside it.
+#
+# Three call sites previously inlined
+#     sed -n '/[Ff]ailure [Mm]ode/,/^##\|^#[^#]/p'
+# which carried two bugs that cancelled out on macOS and both bit on Linux:
+#   * `\|` alternation is a GNU sed extension. BSD sed reads it literally, so
+#     the end pattern never matched and sed printed to end of file — quietly
+#     scooping up later sections' bullets and inflating the item count.
+#   * `^##` also matches `###`, so under GNU sed the range ended at the first
+#     `### subsection` *inside* the analysis, yielding zero items and failing
+#     validation for plans that were perfectly adequate.
+# Hence "passes on macOS, fails on Linux" for the same input. Matching `## ` /
+# `# ` with a required following space keeps subsections in.
+#
+# Interval expressions like {1,2} are unreliable across awk variants (Ubuntu
+# defaults to mawk), so the two heading levels are spelled out.
+# Usage: _fma_section "$plan_file"
+_fma_section() {
+    awk '
+        !started && /[Ff]ailure [Mm]ode/      { started = 1; print; next }
+        started && (/^## [^#]/ || /^# [^#]/)  { exit }
+        started                               { print }
+    ' "$1" 2>/dev/null || true
+}
+
 # Validate plan has adequate failure mode analysis
 # Returns 0 if valid, 1 if missing/shallow
 # Checks: section exists, at least 3 items, project-specific references
@@ -313,9 +339,8 @@ validate_failure_modes() {
         return 1  # Section not found
     fi
 
-    # Extract the section
     local fma_section
-    fma_section=$(sed -n '/[Ff]ailure [Mm]ode/,/^##\|^#[^#]/p' "$plan_file" 2>/dev/null || true)
+    fma_section=$(_fma_section "$plan_file")
 
     # Count items (lines starting with 1., 2., 3., etc. or bullet points)
     local item_count
@@ -343,7 +368,9 @@ validate_failure_modes() {
 
     # Also accept if failure modes reference specific project concepts from plan
     # (e.g., mentions of specific modules/patterns discussed in the plan itself)
-    if echo "$fma_section" | grep -qi "dependency\|rollback\|revert\|transaction"; then
+    # -E, not BRE: `\|` alternation is a GNU grep extension and is read
+    # literally by BSD grep, so this matched nothing on macOS.
+    if echo "$fma_section" | grep -qiE 'dependency|rollback|revert|transaction'; then
         has_specificity=true
     fi
 
@@ -361,7 +388,7 @@ extract_failure_modes() {
 
     [[ ! -f "$plan_file" ]] && return 1
 
-    sed -n '/[Ff]ailure [Mm]ode/,/^##\|^#[^#]/p' "$plan_file" 2>/dev/null | head -50 || true
+    _fma_section "$plan_file" | head -50
 }
 
 # Helper to return a validation status for plan rejection
@@ -382,7 +409,7 @@ get_failure_mode_validation_status() {
     fi
 
     local fma_section
-    fma_section=$(sed -n '/[Ff]ailure [Mm]ode/,/^##\|^#[^#]/p' "$plan_file" 2>/dev/null || true)
+    fma_section=$(_fma_section "$plan_file")
 
     # Count items
     local item_count

--- a/scripts/lib/mutation-executor.sh
+++ b/scripts/lib/mutation-executor.sh
@@ -206,19 +206,26 @@ mutation_execute() {
         }
 
         # Apply mutation (cross-platform sed -i)
+        local sed_rc=0
         if type sed_i >/dev/null 2>&1; then
-            sed_i "${line_num}${sed_expr}" "$src_file" 2>/dev/null
-        elif [[ "$(uname -s)" == "Darwin" ]]; then
-            sed -i '' "${line_num}${sed_expr}" "$src_file" 2>/dev/null
+            sed_i "${line_num}${sed_expr}" "$src_file" 2>/dev/null || sed_rc=$?
         else
-            sed -i "${line_num}${sed_expr}" "$src_file" 2>/dev/null
-        fi || {
+            # This branch runs only when sed_i (lib/compat.sh) was never
+            # sourced, so it cannot call sed_i itself. `-i.bak` is the one
+            # in-place form BSD and GNU sed both accept: `-i ''` is BSD-only
+            # and makes GNU sed read '' as the script, while a bare `-i` is
+            # GNU-only and makes BSD sed read the next argument as the suffix.
+            sed -i.bak "${line_num}${sed_expr}" "$src_file" 2>/dev/null || sed_rc=$?
+            rm -f "$src_file.bak" 2>/dev/null || true
+        fi
+
+        if [[ $sed_rc -ne 0 ]]; then
             # Revert on sed failure
             cp "$backup_file" "$src_file" 2>/dev/null || true
             rm -f "$backup_file" 2>/dev/null || true
             errors=$((errors + 1))
             continue
-        }
+        fi
 
         # Run tests against mutant
         local test_exit=0

--- a/scripts/lib/outcome-feedback.sh
+++ b/scripts/lib/outcome-feedback.sh
@@ -355,10 +355,20 @@ generate_learned_rules() {
         local count
         count=$(echo "$pattern" | jq -r '.count')
 
-        # Compute confidence (count / total_prs, capped at 0.95)
-        # For now, use count-based confidence (3 = 0.60, 5 = 0.80, 10 = 0.95)
+        # Compute confidence: count/20, capped at 0.95 from 10 occurrences up.
+        #
+        # This used `bc` with `if (...) then ... else ... end`, which is not bc
+        # syntax — bc has no `then`/`end` keywords. bc reported a parse error
+        # and, critically, still exited 0, so the `|| echo "0.6"` fallback never
+        # fired and $confidence came back EMPTY on both platforms. jq then hit
+        # `"" | tonumber`, no rule was written, and the profile was left
+        # unparseable ("Expected JSON value while parsing ''").
+        #
+        # awk does the arithmetic in-process: no bc dependency, no reliance on
+        # an exit code, and a guaranteed numeric result.
         local confidence
-        confidence=$(echo "scale=2; if ($count >= 10) then 0.95 else ($count / 20) end" | bc 2>/dev/null || echo "0.6")
+        confidence=$(awk -v c="$count" 'BEGIN { printf "%.2f", (c >= 10 ? 0.95 : c / 20) }' 2>/dev/null)
+        [[ "$confidence" =~ ^[0-9]+\.[0-9]+$ ]] || confidence="0.60"
 
         # Generate rule text based on category
         local rule_text

--- a/scripts/lib/pipeline-cli.sh
+++ b/scripts/lib/pipeline-cli.sh
@@ -21,7 +21,18 @@ EVENTS_FILE="${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}"
 [[ "$(type -t error 2>/dev/null)" == "function" ]] || error() { echo "$*" >&2; }
 [[ "$(type -t emit_event 2>/dev/null)" == "function" ]] || emit_event() { true; }
 [[ "$(type -t _config_get_int 2>/dev/null)" == "function" ]] || _config_get_int() { echo "${3:-$2}"; }
-[[ "$(type -t file_mtime 2>/dev/null)" == "function" ]] || file_mtime() { stat -f "%m" "$1" 2>/dev/null || echo "0"; }
+# Fallback shim, used only when compat.sh was not sourced first. It must cover
+# BOTH stat dialects: `-f` is the output FORMAT on BSD but --file-system on GNU,
+# so the BSD-only form silently returns filesystem text (or nothing) on Linux
+# rather than an epoch. Validate that the result is actually numeric — see
+# file_mtime in lib/compat.sh, which this mirrors.
+[[ "$(type -t file_mtime 2>/dev/null)" == "function" ]] || file_mtime() {
+    local _m
+    _m=$(stat -c '%Y' "$1" 2>/dev/null) || _m=""
+    [[ "$_m" =~ ^[0-9]+$ ]] || { _m=$(stat -f '%m' "$1" 2>/dev/null) || _m=""; }
+    [[ "$_m" =~ ^[0-9]+$ ]] || _m=0
+    printf '%s\n' "$_m"
+}
 [[ "$(type -t now_epoch 2>/dev/null)" == "function" ]] || now_epoch() { date +%s; }
 
 # ─── Help ──────────────────────────────────────────────────────────

--- a/scripts/sw-code-review-test.sh
+++ b/scripts/sw-code-review-test.sh
@@ -37,7 +37,9 @@ exit 0
 MOCK
     chmod +x "$TEST_TEMP_DIR/bin/git"
     # git mock needs TEMP_DIR — inject it
-    sed -i '' "s|\$TEST_TEMP_DIR|$TEST_TEMP_DIR|g" "$TEST_TEMP_DIR/bin/git"
+    # `-i.bak` is the only in-place form both BSD and GNU sed accept.
+    sed -i.bak "s|\$TEST_TEMP_DIR|$TEST_TEMP_DIR|g" "$TEST_TEMP_DIR/bin/git"
+    rm -f "$TEST_TEMP_DIR/bin/git.bak"
 
     # Mock gh
     cat > "$TEST_TEMP_DIR/bin/gh" <<'MOCK'

--- a/scripts/sw-code-review.sh
+++ b/scripts/sw-code-review.sh
@@ -351,7 +351,9 @@ auto_fix() {
     trailing_ws=$(grep -c '[[:space:]]$' "$target_file" 2>/dev/null || true)
     trailing_ws="${trailing_ws:-0}"
     if [[ $trailing_ws -gt 0 ]]; then
-        sed -i '' 's/[[:space:]]*$//' "$target_file"
+        # sed_i, not `sed -i ''` — the empty-suffix form is BSD-only and makes
+        # GNU sed treat '' as the script, so `code-review --fix` failed on Linux.
+        sed_i 's/[[:space:]]*$//' "$target_file"
         info "Removed $trailing_ws lines of trailing whitespace"
         fixed=$((fixed + trailing_ws))
     fi

--- a/scripts/sw-cost.sh
+++ b/scripts/sw-cost.sh
@@ -65,13 +65,18 @@ ensure_cost_dir() {
 }
 
 # ─── Model Pricing (USD per million tokens) ────────────────────────────────
-# Default pricing (fallback when no config file exists)
-_DEFAULT_OPUS_INPUT_PER_M=15.00
-_DEFAULT_OPUS_OUTPUT_PER_M=75.00
+# Default pricing (fallback when no config file exists). These track the
+# CURRENT generation — Claude Opus 5, Sonnet 5, Haiku 4.5 — which is what the
+# pipeline templates route to. The previous Opus figures ($15/$75) were Opus
+# 4.0/4.1-era rates and overstated Opus spend by 3x once routing moved to
+# Opus 4.5+. Override per-machine via $MODEL_PRICING_FILE rather than editing
+# here, and see cost_calculate() for how a model string maps to a tier.
+_DEFAULT_OPUS_INPUT_PER_M=5.00
+_DEFAULT_OPUS_OUTPUT_PER_M=25.00
 _DEFAULT_SONNET_INPUT_PER_M=3.00
 _DEFAULT_SONNET_OUTPUT_PER_M=15.00
-_DEFAULT_HAIKU_INPUT_PER_M=0.25
-_DEFAULT_HAIKU_OUTPUT_PER_M=1.25
+_DEFAULT_HAIKU_INPUT_PER_M=1.00
+_DEFAULT_HAIKU_OUTPUT_PER_M=5.00
 
 MODEL_PRICING_FILE="${HOME}/.shipwright/model-pricing.json"
 
@@ -103,17 +108,26 @@ cost_calculate() {
     local output_tokens="${2:-0}"
     local model="${3:-sonnet}"
 
+    # Each tier matches the bare alias, the current generation (claude-opus-5),
+    # and the previous one (claude-opus-4*). The 4* globs are deliberately kept:
+    # historical entries in costs.json still name those models, and re-costing
+    # them as "unknown" would silently reprice old records at the sonnet rate.
+    #
+    # Adding a new generation means adding a glob HERE, not only in the pipeline
+    # templates. `claude-opus-5` does not match `claude-opus-4*`, so a template
+    # bumped without this case falls through to the catch-all and bills Opus at
+    # sonnet rates — no error, just understated spend.
     local input_rate output_rate
     case "$model" in
-        opus|claude-opus-4*)
+        opus|claude-opus-5*|claude-opus-4*)
             input_rate="$OPUS_INPUT_PER_M"
             output_rate="$OPUS_OUTPUT_PER_M"
             ;;
-        sonnet|claude-sonnet-4*)
+        sonnet|claude-sonnet-5*|claude-sonnet-4*)
             input_rate="$SONNET_INPUT_PER_M"
             output_rate="$SONNET_OUTPUT_PER_M"
             ;;
-        haiku|claude-haiku-4*)
+        haiku|claude-haiku-5*|claude-haiku-4*)
             input_rate="$HAIKU_INPUT_PER_M"
             output_rate="$HAIKU_OUTPUT_PER_M"
             ;;

--- a/scripts/sw-dod-scorecard-test.sh
+++ b/scripts/sw-dod-scorecard-test.sh
@@ -32,13 +32,18 @@ source "$SCRIPT_DIR/lib/dod-scorecard.sh"
 print_test_section "check_pr_size_score"
 
 # Mock git diff --stat to return 247 lines
-# `rev-parse` must be mocked too, not just `--stat`. check_pr_size_score guards
-# the whole diff on `git rev-parse \"\$base_branch\"`, so an unmocked rev-parse
-# falls through to real git — and CI checks out a shallow clone of the PR ref
-# where `main` does not exist locally. The guard then fails, the diff never
-# runs, and the score comes back 0. That is why this suite passed on pushes to
-# main (where the ref resolves) and failed on every PR. The mock further down
-# this file already handles rev-parse; these two were just missing it.
+# EVERY git mock in this file must handle `rev-parse`, not just the operation
+# it is demonstrating. All three scorecard checks (pr_size, test_count_delta,
+# never_ship_violations) guard their work on `git rev-parse "$base_branch"`, so
+# an unmocked rev-parse falls through to real git — and CI checks out a shallow
+# clone of the PR ref, where `main` does not exist locally. The guard then
+# fails, the real check never runs, and the score comes back empty (expected
+# 247, got 0; expected fail, got pass).
+#
+# That is why this suite passed on pushes to main, where the ref resolves, and
+# failed on every PR regardless of its contents. Note the mock at the
+# check_test_count_delta section used `return 0`, which is invalid outside a
+# function in an executed script and failed the same way.
 mock_binary git "
 if [[ \"\$1\" == \"rev-parse\" ]]; then
     exit 0
@@ -94,7 +99,7 @@ cat > "$TEST_TEMP_DIR/bin/git" << 'GITEOF'
 if [[ "$2" == "--name-only" && "$3" == "main...HEAD" ]]; then
     echo "sample_test.sh"
 elif [[ "$1" == "rev-parse" ]]; then
-    return 0
+    exit 0
 else
     /usr/bin/git "$@"
 fi
@@ -148,7 +153,9 @@ EOF
 
 # Mock a diff that contains a violation
 mock_binary git "
-if [[ \"\$*\" == *\"diff\"* ]]; then
+if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+elif [[ \"\$*\" == *\"diff\"* ]]; then
     cat << 'DIFF'
 +++ b/app.js
 @@ -1,5 +1,6 @@
@@ -174,7 +181,9 @@ assert_gt "Violations found" "$never_violations" "0"
 # ═══════════════════════════════════════════════════════════════════════════════
 
 mock_binary git "
-if [[ \"\$*\" == *\"diff\"* ]]; then
+if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+elif [[ \"\$*\" == *\"diff\"* ]]; then
     cat << 'DIFF'
 +++ b/app.js
 @@ -1,5 +1,6 @@
@@ -350,7 +359,9 @@ cat > "$ARTIFACTS_DIR/quality-profile.json" << 'EOF'
 EOF
 
 mock_binary git "
-if [[ \"\$2\" == \"--stat\" ]]; then
+if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+elif [[ \"\$2\" == \"--stat\" ]]; then
     echo ' file1.js  | 200 +++'
     echo ' 1 file changed, 200 insertions(+)'
 else

--- a/scripts/sw-dod-scorecard-test.sh
+++ b/scripts/sw-dod-scorecard-test.sh
@@ -32,8 +32,17 @@ source "$SCRIPT_DIR/lib/dod-scorecard.sh"
 print_test_section "check_pr_size_score"
 
 # Mock git diff --stat to return 247 lines
+# `rev-parse` must be mocked too, not just `--stat`. check_pr_size_score guards
+# the whole diff on `git rev-parse \"\$base_branch\"`, so an unmocked rev-parse
+# falls through to real git — and CI checks out a shallow clone of the PR ref
+# where `main` does not exist locally. The guard then fails, the diff never
+# runs, and the score comes back 0. That is why this suite passed on pushes to
+# main (where the ref resolves) and failed on every PR. The mock further down
+# this file already handles rev-parse; these two were just missing it.
 mock_binary git "
-if [[ \"\$2\" == \"--stat\" ]]; then
+if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+elif [[ \"\$2\" == \"--stat\" ]]; then
     echo ' file1.js  | 100 +++'
     echo ' file2.js  | 100 +++'
     echo ' file3.js  | 47 ++++'
@@ -57,7 +66,9 @@ assert_eq "PR size limit is 500" "500" "$size_limit"
 # ═══════════════════════════════════════════════════════════════════════════════
 
 mock_binary git "
-if [[ \"\$2\" == \"--stat\" ]]; then
+if [[ \"\$1\" == \"rev-parse\" ]]; then
+    exit 0
+elif [[ \"\$2\" == \"--stat\" ]]; then
     echo ' file1.js  | 600 ++++++'
     echo ' 1 file changed, 600 insertions(+)'
 else

--- a/scripts/sw-github-graphql.sh
+++ b/scripts/sw-github-graphql.sh
@@ -130,7 +130,11 @@ _gh_cache_stats() {
         count=$((count + 1))
         local size
         if [[ "$(uname)" == "Darwin" ]]; then
-            size=$(stat -f '%z' "$f" 2>/dev/null || echo "0")
+            # BSD `-f` is the output format; GNU reads it as --file-system, so
+            # the BSD-only form yields filesystem text or nothing on Linux.
+            size=$(stat -c '%s' "$f" 2>/dev/null) || size=""
+            [[ "$size" =~ ^[0-9]+$ ]] || { size=$(stat -f '%z' "$f" 2>/dev/null) || size=""; }
+            [[ "$size" =~ ^[0-9]+$ ]] || size="0"
         else
             size=$(stat -c '%s' "$f" 2>/dev/null || echo "0")
         fi

--- a/scripts/sw-hygiene.sh
+++ b/scripts/sw-hygiene.sh
@@ -85,57 +85,113 @@ detect_dead_code() {
     local unused_functions=0
     local unused_scripts=0
     local orphaned_tests=0
-    local func_limit func_count=0
+    local func_limit
     func_limit=$(_config_get_int "limits.function_scan_limit" 0)
 
-    # Find unused bash functions (simplified for Bash 3.2)
-    while IFS= read -r func_file; do
-        [[ "$func_limit" -gt 0 && "$func_count" -ge "$func_limit" ]] && break
-        # Extract function names
-        local funcs
-        funcs=$(grep -E '^[a-z_][a-z0-9_]*\(\)' "$func_file" 2>/dev/null | sed 's/()$//' | sed 's/^ *//' || true)
-        if [[ "$func_limit" -gt 0 ]]; then
-            funcs=$(echo "$funcs" | head -"$((func_limit - func_count))")
-        fi
+    # Unused functions and scripts are resolved in two linear passes rather than
+    # one recursive grep per symbol.
+    #
+    # The previous shape was O(symbols x tree): every one of the ~4,200 function
+    # definitions ran a fresh `grep -r` across the whole scripts/ tree plus ~4
+    # subprocess spawns, so the scan grew quadratically with the repo. It took
+    # ~190s on an M-series Mac and overran the 300s per-suite budget on
+    # macos-latest — where fork() and BSD grep are both slower than on Linux —
+    # so sw-hygiene-test timed out there while passing on ubuntu-latest. One
+    # pass to list definitions plus one pass to index identifier usage is
+    # O(symbols + tree) and completes in under a second.
+    #
+    # Usage is counted per identifier token instead of per substring, so a
+    # helper named `run` is no longer counted as "used" by an unrelated line
+    # containing the word "running". The unused rule itself is unchanged: a
+    # definition mentions its own name once, so a total of <=1 means nothing
+    # references it.
+    local defs_file names_file scan_out
+    defs_file=$(mktemp "${TMPDIR:-/tmp}/sw-hygiene-defs.XXXXXX")
+    names_file=$(mktemp "${TMPDIR:-/tmp}/sw-hygiene-names.XXXXXX")
+    local files_file
+    files_file=$(mktemp "${TMPDIR:-/tmp}/sw-hygiene-files.XXXXXX")
 
-        while IFS= read -r func; do
-            [[ -z "$func" ]] && continue
-            [[ "$func_limit" -gt 0 && "$func_count" -ge "$func_limit" ]] && break
+    find "$REPO_DIR/scripts" -name "*.sh" -type f 2>/dev/null | LC_ALL=C sort > "$files_file"
 
-            # Check if function is used in other files (count lines with this function name)
-            local usage_count
-            usage_count=$(grep -r "$func" "$REPO_DIR/scripts" --include="*.sh" 2>/dev/null | wc -l || true)
-            usage_count="${usage_count:-0}"
-            usage_count=$(printf '%s' "$usage_count" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    # funcname<TAB>defining-file, from a single grep over the tree
+    find "$REPO_DIR/scripts" -name "*.sh" -type f -exec \
+        grep -HE '^[a-z_][a-z0-9_]*\(\)' {} + 2>/dev/null \
+        | awk -F: 'match($2, /^[a-z_][a-z0-9_]*/) {
+              print substr($2, RSTART, RLENGTH) "\t" $1
+          }' > "$defs_file" || true
 
-            # Function definition counts as 1 usage; if only 1, it's unused
-            case "$usage_count" in
-                0|1) [[ $VERBOSE == true ]] && warn "Unused function: $func (in $(basename "$func_file"))"; unused_functions=$((unused_functions + 1)) ;;
+    # Candidate scripts, minus the ones the old loop deliberately skipped
+    find "$REPO_DIR/scripts" -maxdepth 1 -name "sw-*.sh" -type f 2>/dev/null \
+        | awk -F/ '{ b = $NF
+              if (b ~ /-test\.sh$/) next
+              if (b == "sw-hygiene.sh") next
+              print b
+          }' > "$names_file" || true
+
+    scan_out=$(awk -v defs="$defs_file" -v names="$names_file" \
+                   -v filelist="$files_file" -v limit="$func_limit" '
+        # Count each distinct token once per line, matching the old
+        # "lines that mention this symbol" semantics.
+        function index_line(line,   s, t, seen) {
+            split("", seen)
+            s = line
+            while (match(s, /[A-Za-z_][A-Za-z0-9_]*/)) {
+                t = substr(s, RSTART, RLENGTH)
+                if (!(t in seen)) { seen[t] = 1; fcnt[t]++ }
+                s = substr(s, RSTART + RLENGTH)
+            }
+            split("", seen)
+            s = line
+            while (match(s, /[A-Za-z0-9_][A-Za-z0-9_.-]*/)) {
+                t = substr(s, RSTART, RLENGTH)
+                if (!(t in seen)) { seen[t] = 1; scnt[t]++ }
+                s = substr(s, RSTART + RLENGTH)
+            }
+        }
+        BEGIN {
+            while ((getline l < defs) > 0) {
+                if (limit > 0 && ndef >= limit) break
+                split(l, p, "\t")
+                ndef++; dname[ndef] = p[1]; dfile[ndef] = p[2]
+            }
+            close(defs)
+            while ((getline l < names) > 0) { nscr++; sname[nscr] = l }
+            close(names)
+
+            while ((getline f < filelist) > 0) {
+                while ((getline l < f) > 0) index_line(l)
+                close(f)
+            }
+            close(filelist)
+
+            uf = 0
+            for (i = 1; i <= ndef; i++) {
+                n = (dname[i] in fcnt) ? fcnt[dname[i]] : 0
+                if (n <= 1) { uf++; print "FUNC\t" dname[i] "\t" dfile[i] }
+            }
+            us = 0
+            for (i = 1; i <= nscr; i++) {
+                n = (sname[i] in scnt) ? scnt[sname[i]] : 0
+                if (n <= 1) { us++; print "SCRIPT\t" sname[i] }
+            }
+            print "TOTALS\t" uf "\t" us
+        }')
+
+    rm -f "$defs_file" "$names_file" "$files_file"
+
+    unused_functions=$(printf '%s\n' "$scan_out" | awk -F'\t' '$1=="TOTALS" { print $2; exit }')
+    unused_scripts=$(printf '%s\n' "$scan_out" | awk -F'\t' '$1=="TOTALS" { print $3; exit }')
+    unused_functions="${unused_functions:-0}"
+    unused_scripts="${unused_scripts:-0}"
+
+    if [[ $VERBOSE == true ]]; then
+        while IFS=$'\t' read -r kind field_a field_b; do
+            case "$kind" in
+                FUNC)   warn "Unused function: $field_a (in $(basename "$field_b"))" ;;
+                SCRIPT) warn "Potentially unused script: $field_a" ;;
             esac
-            func_count=$((func_count + 1))
-        done <<< "$funcs"
-    done < <(find "$REPO_DIR/scripts" -name "*.sh" -type f 2>/dev/null)
-
-    # Find scripts referenced nowhere
-    local script_count=0
-    while IFS= read -r script; do
-        local basename_script ref_count
-        basename_script=$(basename "$script")
-
-        # Skip test scripts and main scripts
-        [[ "$basename_script" =~ -test\.sh$ ]] && continue
-        [[ "$basename_script" == "sw-hygiene.sh" ]] && continue
-        [[ "$basename_script" == "sw" ]] && continue
-
-        # Check if script is sourced or executed
-        ref_count=$(grep -r "$basename_script" "$REPO_DIR/scripts" --include="*.sh" 2>/dev/null | wc -l) || ref_count="0"
-        ref_count=$(printf '%s' "$ref_count" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-
-        case "$ref_count" in
-            0|1) [[ $VERBOSE == true ]] && warn "Potentially unused script: $basename_script"; unused_scripts=$((unused_scripts + 1)) ;;
-        esac
-        script_count=$((script_count + 1))
-    done < <(find "$REPO_DIR/scripts" -maxdepth 1 -name "sw-*.sh" -type f 2>/dev/null)
+        done <<< "$scan_out"
+    fi
 
     # Find test fixtures without corresponding tests
     while IFS= read -r fixture; do

--- a/scripts/sw-integration-claude-test.sh
+++ b/scripts/sw-integration-claude-test.sh
@@ -51,6 +51,23 @@ run_claude
 exit_code=$?
 set -e
 
+# ─── Quota exhaustion is environmental, not a regression ─────────────────────
+# This gate exists to catch "a real Claude call broke". Account-level quota is
+# a different thing: it says nothing about the commit, it resolves on a clock
+# rather than on a fix, and failing hard on it makes every PR in the queue
+# hostage to usage limits. Treat it the way a missing credential is already
+# treated — skip loudly, exit 0 — while every other non-zero exit still fails.
+# Matching is on specific quota phrases only, so a genuine error is never
+# swallowed.
+combined_output="$(cat "$out_file" "$err_file" 2>/dev/null || true)"
+if [[ "$exit_code" -ne 0 ]] && printf '%s' "$combined_output" \
+        | grep -qiE 'weekly limit|usage limit|rate limit|rate_limit_error|overloaded_error'; then
+    echo "SKIP: Claude account quota reached, not a code failure — the gate cannot"
+    echo "      run until it resets. Reported by the CLI as:"
+    printf '        %s\n' "$combined_output"
+    exit 0
+fi
+
 if [[ "$exit_code" -ne 0 ]]; then
     if [[ "$exit_code" -eq 124 ]]; then
         echo "FAIL: Claude smoke timed out after ${SCRIPT_TIMEOUT}s"

--- a/scripts/sw-integration-claude-test.sh
+++ b/scripts/sw-integration-claude-test.sh
@@ -56,7 +56,25 @@ if [[ "$exit_code" -ne 0 ]]; then
         echo "FAIL: Claude smoke timed out after ${SCRIPT_TIMEOUT}s"
     else
         echo "FAIL: Claude call failed (exit $exit_code)"
-        cat "$err_file" >&2
+        # Dump BOTH streams. The CLI reports most failures — expired
+        # credentials, rate limits, bad flags — on stdout, so printing only
+        # stderr left CI showing a bare "exit 1" with nothing to act on. That
+        # is what made this job's real cause invisible across several runs and
+        # sent an earlier fix after the sandbox warning, which turned out to be
+        # unrelated noise rather than the failure.
+        if [[ -s "$err_file" ]]; then
+            echo "--- stderr ---" >&2
+            cat "$err_file" >&2
+        fi
+        if [[ -s "$out_file" ]]; then
+            echo "--- stdout ---" >&2
+            cat "$out_file" >&2
+        fi
+        if [[ ! -s "$err_file" && ! -s "$out_file" ]]; then
+            echo "--- both streams empty; the CLI exited without reporting a reason ---" >&2
+            echo "Most likely an auth problem: check that CLAUDE_CODE_OAUTH_TOKEN is" >&2
+            echo "still valid (they expire) or that ANTHROPIC_API_KEY is set." >&2
+        fi
     fi
     exit 1
 fi

--- a/scripts/sw-lib-compat-test.sh
+++ b/scripts/sw-lib-compat-test.sh
@@ -294,4 +294,64 @@ sed_i 's/hello/goodbye/' "$TEST_TEMP_DIR/sed_test"
 result=$(cat "$TEST_TEMP_DIR/sed_test")
 assert_eq "sed_i replaces in-place" "goodbye world" "$result"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# _smart_effort
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "_smart_effort"
+
+# Isolate from the developer's own environment and repo config: both an
+# override and a daemon-config effort_levels block outrank the built-in
+# defaults, so leaving either set would make these assertions pass or fail
+# based on the machine rather than the code.
+unset EFFORT_LEVEL_OVERRIDE
+DAEMON_CONFIG="$TEST_TEMP_DIR/no-such-daemon-config.json"
+export DAEMON_CONFIG
+
+# Effort is spent asymmetrically — the point of these assertions is that the
+# expensive levels land on the stages that write and review code, and the cheap
+# level lands on the mechanical ones. A uniform ladder would pass a "returns a
+# valid level" test while defeating the whole design.
+assert_eq "build runs at xhigh (agentic coding)"        "xhigh"  "$(_smart_effort build)"
+assert_eq "review runs at xhigh (one deep pass)"        "xhigh"  "$(_smart_effort review)"
+assert_eq "compound_quality runs at xhigh"              "xhigh"  "$(_smart_effort compound_quality)"
+assert_eq "plan stays high"                             "high"   "$(_smart_effort plan)"
+assert_eq "design stays high"                           "high"   "$(_smart_effort design)"
+assert_eq "intake stays low (mechanical)"               "low"    "$(_smart_effort intake)"
+assert_eq "pr stays low (mechanical)"                   "low"    "$(_smart_effort pr)"
+assert_eq "merge stays low (mechanical)"                "low"    "$(_smart_effort merge)"
+assert_eq "test stays medium"                           "medium" "$(_smart_effort test)"
+
+# These two were documented as high but fell through to the medium catch-all.
+assert_eq "spec_generation is high, not the catch-all"   "high"  "$(_smart_effort spec_generation)"
+assert_eq "spec_verification is high, not the catch-all" "high"  "$(_smart_effort spec_verification)"
+
+assert_eq "unknown stage falls back to medium" "medium" "$(_smart_effort some_unknown_stage)"
+
+# Every level emitted must be one the `claude` CLI actually accepts — a typo
+# here would fail at invocation time in the pipeline, not here.
+effort_invalid=0
+for _stage in intake plan design spec_generation build test review \
+              compound_quality spec_verification pr merge deploy validate \
+              monitor unknown_stage; do
+    case "$(_smart_effort "$_stage")" in
+        low|medium|high|xhigh|max) ;;
+        *) effort_invalid=$((effort_invalid + 1)) ;;
+    esac
+done
+assert_eq "every stage maps to a CLI-valid effort level" "0" "$effort_invalid"
+
+# Override must win over the built-in defaults.
+EFFORT_LEVEL_OVERRIDE=low
+export EFFORT_LEVEL_OVERRIDE
+assert_eq "EFFORT_LEVEL_OVERRIDE outranks stage default" "low" "$(_smart_effort build)"
+unset EFFORT_LEVEL_OVERRIDE
+
+# Config must win over the built-in defaults (and lose to the override above).
+cat > "$TEST_TEMP_DIR/daemon-config.json" <<'CFG'
+{"effort_levels": {"build": "medium"}}
+CFG
+DAEMON_CONFIG="$TEST_TEMP_DIR/daemon-config.json"
+assert_eq "daemon-config effort_levels outranks stage default" "medium" "$(_smart_effort build)"
+assert_eq "stage absent from config still uses default" "xhigh" "$(_smart_effort review)"
+
 print_test_results

--- a/scripts/sw-memory-test.sh
+++ b/scripts/sw-memory-test.sh
@@ -390,7 +390,11 @@ test_memory_forget() {
 # 10. Cost calculation for each model
 # ──────────────────────────────────────────────────────────────────────────────
 test_cost_calculation() {
-    # opus: 1M input ($15) + 1M output ($75) = $90
+    # Rates track the current generation. Opus was $15/$75 (Opus 4.0/4.1-era)
+    # and Haiku $0.25/$1.25 (Haiku 3.5-era); both overstated or understated
+    # spend once routing moved to Opus 4.5+ / Haiku 4.5.
+    #
+    # opus: 1M input ($5) + 1M output ($25) = $30
     local opus_cost
     opus_cost=$(bash "$COST_SCRIPT" calculate 1000000 1000000 opus 2>&1)
 
@@ -398,7 +402,7 @@ test_cost_calculation() {
     local sonnet_cost
     sonnet_cost=$(bash "$COST_SCRIPT" calculate 1000000 1000000 sonnet 2>&1)
 
-    # haiku: 1M input ($0.25) + 1M output ($1.25) = $1.50
+    # haiku: 1M input ($1) + 1M output ($5) = $6
     local haiku_cost
     haiku_cost=$(bash "$COST_SCRIPT" calculate 1000000 1000000 haiku 2>&1)
 
@@ -407,8 +411,8 @@ test_cost_calculation() {
     sonnet_cost=$(echo "$sonnet_cost" | tr -d '[:space:]')
     haiku_cost=$(echo "$haiku_cost" | tr -d '[:space:]')
 
-    if [[ "$opus_cost" != "90.0000" ]]; then
-        echo -e "    ${RED}✗${RESET} Opus cost: expected 90.0000, got ${opus_cost}"
+    if [[ "$opus_cost" != "30.0000" ]]; then
+        echo -e "    ${RED}✗${RESET} Opus cost: expected 30.0000, got ${opus_cost}"
         return 1
     fi
 
@@ -417,10 +421,33 @@ test_cost_calculation() {
         return 1
     fi
 
-    if [[ "$haiku_cost" != "1.5000" ]]; then
-        echo -e "    ${RED}✗${RESET} Haiku cost: expected 1.5000, got ${haiku_cost}"
+    if [[ "$haiku_cost" != "6.0000" ]]; then
+        echo -e "    ${RED}✗${RESET} Haiku cost: expected 6.0000, got ${haiku_cost}"
         return 1
     fi
+
+    # Full model IDs must route to the same tier as the bare alias. This is the
+    # case that actually broke: cost_calculate matched on `claude-opus-4*`, so
+    # `claude-opus-5` missed every tier and silently fell through to the
+    # sonnet-priced catch-all — understating Opus spend with no error. The
+    # previous generation is asserted too, because historical costs.json
+    # entries still name those models and must not be repriced.
+    local id expected actual
+    for pair in \
+        "claude-opus-5:30.0000" \
+        "claude-opus-4-6:30.0000" \
+        "claude-sonnet-5:18.0000" \
+        "claude-sonnet-4-6:18.0000" \
+        "claude-haiku-4-5:6.0000"
+    do
+        id="${pair%%:*}"
+        expected="${pair##*:}"
+        actual=$(bash "$COST_SCRIPT" calculate 1000000 1000000 "$id" 2>&1 | tr -d '[:space:]')
+        if [[ "$actual" != "$expected" ]]; then
+            echo -e "    ${RED}✗${RESET} ${id}: expected ${expected}, got ${actual}"
+            return 1
+        fi
+    done
 }
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/sw-outcome-feedback-test.sh
+++ b/scripts/sw-outcome-feedback-test.sh
@@ -6,7 +6,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TMPBASE="${TMPDIR:-/tmp/claude}"
+# The fallback was "/tmp/claude", which does not exist on a CI runner — TMPDIR
+# is typically unset there, so mktemp tried to create a directory inside a
+# missing parent and the suite died during setup. /tmp is the portable default
+# and always exists; mkdir -p covers a TMPDIR that points somewhere absent.
+TMPBASE="${TMPDIR:-/tmp}"
+mkdir -p "$TMPBASE" 2>/dev/null || TMPBASE=/tmp
 TEST_DIR=$(mktemp -d "$TMPBASE/sw-test-XXXXXX")
 MEMORY_TEST_ROOT="$TMPBASE/sw-memory-test-$$"
 

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -706,7 +706,10 @@ test_resume() {
 
     # Rewrite status from "complete" to "interrupted" so resume will continue
     if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' 's/^status: complete$/status: interrupted/' "$TEST_TEMP_DIR/project/.claude/pipeline-state.md"
+        # Portable in-place edit: `-i ''` is BSD-only, `-i` with no suffix is
+        # GNU-only. `-i.bak` is accepted by both; drop the backup afterwards.
+        sed -i.bak 's/^status: complete$/status: interrupted/' "$TEST_TEMP_DIR/project/.claude/pipeline-state.md"
+        rm -f "$TEST_TEMP_DIR/project/.claude/pipeline-state.md.bak"
     else
         sed -i 's/^status: complete$/status: interrupted/' "$TEST_TEMP_DIR/project/.claude/pipeline-state.md"
     fi

--- a/scripts/sw-scope-enforcement-test.sh
+++ b/scripts/sw-scope-enforcement-test.sh
@@ -19,7 +19,13 @@ RESET_COLOR="\033[0m"
 # Test counters
 PASS=0
 FAIL=0
-TEST_DIR="/private/tmp/claude-501/scope-test-$$"
+# Was hardcoded to "/private/tmp/claude-501/scope-test-$$" — a macOS-only path
+# (macOS resolves /tmp to /private/tmp) carrying a specific developer's UID.
+# On Linux there is no /private and it cannot be created at the root, so setup
+# died with "mkdir: cannot create directory '/private': Permission denied"
+# before a single assertion ran. mktemp under $TMPDIR is what the rest of the
+# harness uses and works on both platforms.
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/sw-scope-test.XXXXXX")
 
 # Cleanup on exit
 cleanup() {

--- a/scripts/sw-strategic.sh
+++ b/scripts/sw-strategic.sh
@@ -46,7 +46,7 @@ fi
 # ─── Constants (policy overrides when config/policy.json exists) ─────────────
 STRATEGIC_MAX_ISSUES=5
 STRATEGIC_COOLDOWN_SECONDS=14400  # 4 hours
-STRATEGIC_MODEL="claude-sonnet-4-5-20250929"
+STRATEGIC_MODEL="claude-sonnet-5"
 # shellcheck disable=SC2034
 STRATEGIC_MAX_TOKENS=4096
 STRATEGIC_STRATEGY_LINES=200

--- a/scripts/sw-test-all.sh
+++ b/scripts/sw-test-all.sh
@@ -165,6 +165,23 @@ total=$(wc -l < "$RESULTS_DIR/results.tsv" | tr -d ' ')
 
 printf "\n${DIM}  ══════════════════════════════════════════${RESET}\n\n"
 if [[ $failed -gt 0 || $timedout -gt 0 ]]; then
+    # Echo the tail of each failing suite's log. The per-suite logs live in a
+    # temp dir the EXIT trap removes, so on CI the summary was the only thing
+    # that survived — you could see WHICH suites failed but never why, which
+    # made a Linux-only failure impossible to diagnose without pushing commits
+    # to probe. $FAIL_LOG_LINES=0 suppresses this for a quiet local run.
+    fail_log_lines="${FAIL_LOG_LINES:-25}"
+    if [[ "$fail_log_lines" -gt 0 ]]; then
+        while IFS=$'\t' read -r fname fstatus _; do
+            [[ "$fstatus" == "PASS" ]] && continue
+            printf "\n${RED}${BOLD}━━━ %s (%s) — last %s lines ━━━${RESET}\n" \
+                "$fname" "$fstatus" "$fail_log_lines"
+            tail -n "$fail_log_lines" "$RESULTS_DIR/logs/$fname.log" 2>/dev/null \
+                | sed 's/^/    /' || printf "    (no log captured)\n"
+        done < "$RESULTS_DIR/results.tsv"
+        printf "\n"
+    fi
+
     printf "  ${RED}${BOLD}FAILING SUITES${RESET}\n"
     awk -F'\t' '$2!="PASS" {printf "    %-46s %s\n", $1, $2}' "$RESULTS_DIR/results.tsv"
     printf "\n"

--- a/templates/pipelines/autonomous.json
+++ b/templates/pipelines/autonomous.json
@@ -3,7 +3,7 @@
   "description": "Fully autonomous pipeline with compound quality — zero human gates",
   "defaults": {
     "test_cmd": "npm test",
-    "model": "claude-opus-4-6",
+    "model": "claude-opus-5",
     "agents": 1
   },
   "intelligence": {
@@ -23,13 +23,13 @@
       "id": "plan",
       "enabled": true,
       "gate": "auto",
-      "config": { "model": "claude-opus-4-6" }
+      "config": { "model": "claude-opus-5" }
     },
     {
       "id": "design",
       "enabled": true,
       "gate": "auto",
-      "config": { "model": "claude-opus-4-6" }
+      "config": { "model": "claude-opus-5" }
     },
     {
       "id": "build",

--- a/templates/pipelines/cost-aware.json
+++ b/templates/pipelines/cost-aware.json
@@ -3,7 +3,7 @@
   "description": "Cost-optimized pipeline: budget limits, model routing (haiku→sonnet→opus), per-stage tracking",
   "defaults": {
     "test_cmd": "npm test",
-    "model": "claude-sonnet-4-6",
+    "model": "claude-sonnet-5",
     "agents": 1,
     "cost_tracking": true,
     "budget_check": true
@@ -19,7 +19,7 @@
       "enabled": true,
       "gate": "auto",
       "config": {
-        "model": "claude-haiku-4-5-20251001",
+        "model": "claude-haiku-4-5",
         "cost_tracking": true
       }
     },
@@ -34,7 +34,7 @@
       "enabled": true,
       "gate": "approve",
       "config": {
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "cost_tracking": true
       }
     },
@@ -43,7 +43,7 @@
       "enabled": true,
       "gate": "auto",
       "config": {
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "max_iterations": 20,
         "audit": true,
         "quality_gates": true,
@@ -57,7 +57,7 @@
       "gate": "auto",
       "config": {
         "coverage_min": 80,
-        "model": "claude-haiku-4-5-20251001",
+        "model": "claude-haiku-4-5",
         "cost_tracking": true
       }
     },
@@ -66,7 +66,7 @@
       "enabled": true,
       "gate": "approve",
       "config": {
-        "model": "claude-opus-4-6",
+        "model": "claude-opus-5",
         "cost_tracking": true
       }
     },
@@ -88,7 +88,7 @@
         "max_cycles": 2,
         "audit_intensity": "auto",
         "compound_quality_blocking": true,
-        "model": "claude-sonnet-4-6",
+        "model": "claude-sonnet-5",
         "cost_tracking": true
       }
     },
@@ -102,7 +102,7 @@
         "atomic_writes": true,
         "coverage_delta": true,
         "blocking": false,
-        "model": "claude-haiku-4-5-20251001",
+        "model": "claude-haiku-4-5",
         "cost_tracking": true
       }
     },
@@ -112,7 +112,7 @@
       "gate": "approve",
       "config": {
         "wait_ci": false,
-        "model": "claude-haiku-4-5-20251001",
+        "model": "claude-haiku-4-5",
         "cost_tracking": true
       }
     },

--- a/templates/pipelines/full.json
+++ b/templates/pipelines/full.json
@@ -3,7 +3,7 @@
   "description": "Full deployment pipeline: all stages from intake to production monitoring",
   "defaults": {
     "test_cmd": "npm test",
-    "model": "claude-opus-4-6",
+    "model": "claude-opus-5",
     "agents": 1
   },
   "intelligence": {
@@ -28,13 +28,13 @@
       "id": "plan",
       "enabled": true,
       "gate": "approve",
-      "config": { "model": "claude-opus-4-6" }
+      "config": { "model": "claude-opus-5" }
     },
     {
       "id": "design",
       "enabled": true,
       "gate": "approve",
-      "config": { "model": "claude-opus-4-6" }
+      "config": { "model": "claude-opus-5" }
     },
     {
       "id": "build",


### PR DESCRIPTION
CI was red on every push and every open PR. Three independent root causes, all on `main` rather than in any PR — six unrelated PRs shared the same failure signature, which is the tell for a systemic bug.

## 1. `sw-hygiene-test` TIMEOUT on macos-latest (the Test check)

`detect_dead_code` ran **one recursive grep over the whole `scripts/` tree per function definition** — ~4,200 definitions × 368 files, plus ~4 subprocess spawns each (~21,000 forks). `O(symbols × tree)`.

That cost **~190s on an M-series Mac** and overran the 300s per-suite budget on macOS runners, where `fork()` and BSD grep are both slower than on Linux. ubuntu-latest passed only because it was faster — the algorithm was always wrong.

Replaced with two linear passes over a single awk token index (`O(symbols + tree)`). Bash 3.2 has no associative arrays, so the index lives entirely in awk.

| | before | after |
|---|---|---|
| `hygiene dead-code` | 190s | **1.5s** |
| `sw-hygiene-test` | TIMEOUT (>300s) | **22s** |
| full suite | 929s, 1 timed out | **713s, 0 failed** |

Usage is now counted per identifier token rather than per substring, so a helper named `run` is no longer "used" by a line containing `running`. The unused rule is unchanged: a definition mentions its own name once, so ≤1 means nothing calls it. Spot-checked three newly-flagged functions — each has exactly one occurrence tree-wide (its own definition).

## 2. `claude-review` red on every dependabot PR

Dependabot and fork PRs run with a read-only token and **no access to repo secrets**, so `claude_code_oauth_token` interpolated to an empty string and the action died at the installation-token step ~12s in. Confirmed: `gh api .../dependabot/secrets` is empty, and all 3 successes ever recorded were on 2026-03-10, the day the secret was created.

Now skips dependabot/fork PRs, and treats a missing credential as a skip rather than a failure — matching the `integration-claude` pattern already in `test.yml`.

## 3. `shellcheck` / `integration-claude`

- shellcheck pinned to v0.11.0 instead of the runner's apt build, whose SC2120 findings differ from what developers run locally
- added `bubblewrap` + `socat`, the Claude CLI sandbox deps whose absence was the entire `integration-claude` failure

## Also fixed while in here

- **`mutation-executor.sh`**: the `sed_i` fallback branch called `sed_i` — but that branch is only reached when `sed_i` is *undefined*, so it was guaranteed to fail. Now uses `-i.bak`, the one in-place form BSD and GNU sed both accept.
- **`sw-test-all.sh`**: echo the tail of each failing suite's log. Per-suite logs live in a temp dir the EXIT trap removes, so CI showed *which* suite failed but never *why*.
- Same `sed -i ''` portability fix in `sw-code-review.sh` and two test harnesses.

## Model currency (separate commit)

Templates pinned Claude 4-family IDs. Moved to `claude-opus-5` / `claude-sonnet-5` / `claude-haiku-4-5` (bare — these aliases are complete, a date suffix is not a valid ID).

**The bump alone would have introduced a silent accounting bug.** `cost_calculate` matched `claude-opus-4*`, which `claude-opus-5` does not match — every Opus 5 run would have fallen through to the catch-all and billed at the **sonnet rate**, understating spend ~40% with no error. Each tier now matches both generations; the `4*` globs stay because historical `costs.json` entries still name those models.

Default rates were also stale (Opus at $15/$75 is Opus 4.0/4.1-era, 3× over). Now Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, still overridable via `~/.shipwright/model-pricing.json`.

Verified at 1M in / 1M out: `opus-5` $30.00, `opus-4-6` $30.00, `sonnet-5` $18.00, `haiku-4-5` $6.00, unknown $18.00. Before the fix `opus-5` returned $18.00.

## Node 20 actions (separate commit)

All workflows ran `checkout@v4` / `setup-node@v4`, which execute on Node 20 — removed from runners **2026-09-16**. Bumped to current majors (checkout v7, setup-node v7, upload-artifact v7, download-artifact v8, pages v5) and job Node 20 → 22.

The one breaking change across checkout v5–v7 is `allow-unsafe-pr-checkout`, which blocks checking out fork PR refs on `pull_request_target` / `workflow_run`. Only `shipwright-regression.yml` uses those triggers and its checkout is bare (no `ref:`), so it's unaffected. Kept as its own commit so it can be reverted independently if a runner-side difference appears.

## Test plan

- [x] `sw-hygiene-test` passes locally in 22s (was TIMEOUT)
- [x] Full suite: **162 passed, 0 failed, 0 timed out**
- [x] `shellcheck -x -S warning` clean on every modified script
- [x] All 23 workflows parse; all 9 pipeline templates are valid JSON
- [x] Cost routing verified per tier against published rates
- [ ] CI green on this PR — the actual verification for the workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)