### PR TITLE
feat: stop the build loop cold-starting a Claude session every iteration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -263,6 +263,27 @@ Override globally via CLI: `--effort high` or via `daemon-config.json`:
 
 Environment variables: `SW_EFFORT_LEVEL`, `SW_FALLBACK_MODEL`.
 
+### Prompt-Cache Stability and Session Continuity
+
+Two loop-level controls that affect cost rather than behavior. Both target the
+same thing: the build loop used to start a **cold Claude session every
+iteration**, recomposing the prompt and re-paying cache writes.
+
+| Control | Default | Effect |
+| ------- | ------- | ------ |
+| `LOOP_STABLE_PROMPT_PREFIX` | `true` | Passes `--exclude-dynamic-system-prompt-sections`, moving per-machine sections (cwd, env, memory paths, **git status**) out of the system prompt. Prompt caching is a prefix match, and git status changes constantly mid-loop — leaving it in the prefix invalidated everything after it on every iteration. Set `false` to restore the old behavior. |
+| `--session-continuity` / `LOOP_SESSION_CONTINUITY=1` / `loop.session_continuity` | **off** | Reuses one `--session-id` across iterations so they continue a single conversation instead of cold-starting. |
+
+Session continuity is **opt-in on purpose**. It changes conversation semantics —
+the model carries prior turns rather than being re-briefed from `progress.md` —
+so roll it out measured: run a pipeline with and without it and compare
+`shipwright cost show`. A deliberate session restart (context-exhaustion
+recovery) always allocates a **new** session id, because that path exists
+precisely to drop stale context and re-orient from `progress.md`.
+
+Note `shipwright loop --resume` is unrelated: that re-reads
+`.claude/loop-state.md`, it does not continue a Claude session.
+
 ## Intelligent Defaults
 
 Pipeline behavior is config-driven via `daemon-config.json`. Three helper functions in `scripts/lib/compat.sh` provide intelligent configuration chaining (env var → daemon-config.json → user config → hardcoded default):

--- a/scripts/lib/compat.sh
+++ b/scripts/lib/compat.sh
@@ -219,6 +219,34 @@ file_mtime() {
     printf '0\n'
 }
 
+# ─── UUID generation (for --session-id, which requires a valid UUID) ───────
+# uuidgen ships with macOS and with util-linux on most distros, but is not
+# guaranteed; /proc/sys/kernel/random/uuid covers Linux images without it, and
+# the awk form is a last resort so callers never have to handle "no UUID".
+# Usage: new_uuid
+new_uuid() {
+    local u=""
+    if command -v uuidgen >/dev/null 2>&1; then
+        u=$(uuidgen 2>/dev/null | tr 'A-Z' 'a-z')
+    fi
+    if [[ ! "$u" =~ ^[0-9a-f-]{36}$ ]] && [[ -r /proc/sys/kernel/random/uuid ]]; then
+        u=$(tr -d '\n' < /proc/sys/kernel/random/uuid)
+    fi
+    if [[ ! "$u" =~ ^[0-9a-f-]{36}$ ]]; then
+        u=$(awk 'BEGIN {
+            srand()
+            h = "0123456789abcdef"
+            for (i = 1; i <= 36; i++) {
+                if (i == 9 || i == 14 || i == 19 || i == 24) { printf "-"; continue }
+                if (i == 15) { printf "4"; continue }
+                if (i == 20) { printf substr("89ab", int(rand() * 4) + 1, 1); continue }
+                printf substr(h, int(rand() * 16) + 1, 1)
+            }
+        }')
+    fi
+    printf '%s\n' "$u"
+}
+
 # ─── Timeout command (macOS may lack timeout; gtimeout from coreutils) ─────
 # Usage: _timeout <seconds> <command> [args...]
 _timeout() {

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -517,6 +517,26 @@ build_claude_flags() {
         flags+=("--fallback-model" "$FALLBACK_MODEL")
     fi
 
+    # Keep the cached prompt prefix stable across iterations. The per-machine
+    # sections (cwd, env info, memory paths, git status) sit at the FRONT of the
+    # system prompt, and prompt caching is a prefix match — so git status
+    # changing between iterations, which it does constantly during a build loop,
+    # invalidated everything after it. This moves them into the first user
+    # message instead. The CLI ignores the flag when a custom --system-prompt is
+    # in play, which this loop does not pass.
+    if [[ "${LOOP_STABLE_PROMPT_PREFIX:-true}" == "true" ]]; then
+        flags+=("--exclude-dynamic-system-prompt-sections")
+    fi
+
+    # Session continuity: reuse one session across iterations so the loop stops
+    # paying a cold start (and a fresh cache write) every time. LOOP_SESSION_ID
+    # is only set when continuity is enabled — see sw-loop.sh — and is
+    # regenerated on a deliberate session restart so context-exhaustion recovery
+    # still gets the clean slate it depends on.
+    if [[ -n "${LOOP_SESSION_ID:-}" ]]; then
+        flags+=("--session-id" "$LOOP_SESSION_ID")
+    fi
+
     echo "${flags[*]}"
 }
 

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -231,6 +231,67 @@ else
     assert_fail "build_claude_flags supports --fallback-model"
 fi
 
+# ─── build_claude_flags: cache prefix + session continuity ──────────────────
+# These INVOKE the function and assert on what it emits, rather than grepping
+# the source for a string. A grep passes even when the flag never reaches the
+# command line — which is the whole failure mode worth guarding against here.
+echo -e "${DIM}  prompt-cache and session flags (behavioral)${RESET}"
+_flags_with() {
+    bash -c '
+        source "'"$SCRIPT_DIR"'/lib/compat.sh" >/dev/null 2>&1
+        source "'"$SCRIPT_DIR"'/lib/loop-iteration.sh" >/dev/null 2>&1
+        MODEL=claude-opus-5; SKIP_PERMISSIONS=false; MAX_TURNS=""
+        EFFORT_LEVEL=""; FALLBACK_MODEL=""
+        '"$1"'
+        build_claude_flags
+    ' 2>/dev/null
+}
+
+# Stable prefix is on by default: per-machine sections (notably git status,
+# which changes constantly mid-loop) must not sit in the cached prefix.
+if [[ "$(_flags_with '')" == *"--exclude-dynamic-system-prompt-sections"* ]]; then
+    assert_pass "stable prompt prefix is on by default"
+else
+    assert_fail "stable prompt prefix is on by default"
+fi
+
+if [[ "$(_flags_with 'LOOP_STABLE_PROMPT_PREFIX=false')" != *"--exclude-dynamic-system-prompt-sections"* ]]; then
+    assert_pass "stable prompt prefix can be disabled"
+else
+    assert_fail "stable prompt prefix can be disabled"
+fi
+
+# Session continuity is opt-in, so no --session-id unless LOOP_SESSION_ID is set.
+# A stray --session-id would silently chain unrelated pipeline runs together.
+if [[ "$(_flags_with '')" != *"--session-id"* ]]; then
+    assert_pass "no --session-id when continuity is off"
+else
+    assert_fail "no --session-id when continuity is off"
+fi
+
+if [[ "$(_flags_with 'LOOP_SESSION_ID=11111111-2222-4333-8444-555555555555')" \
+      == *"--session-id 11111111-2222-4333-8444-555555555555"* ]]; then
+    assert_pass "--session-id passed through when continuity is on"
+else
+    assert_fail "--session-id passed through when continuity is on"
+fi
+
+# The CLI rejects a --session-id that is not a valid UUID, so a malformed
+# generator would break every iteration rather than degrade.
+_uuid=$(bash -c 'source "'"$SCRIPT_DIR"'/lib/compat.sh" >/dev/null 2>&1; new_uuid' 2>/dev/null)
+if [[ "$_uuid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    assert_pass "new_uuid emits a valid UUID"
+else
+    assert_fail "new_uuid emits a valid UUID" "got: $_uuid"
+fi
+
+_uuid2=$(bash -c 'source "'"$SCRIPT_DIR"'/lib/compat.sh" >/dev/null 2>&1; new_uuid' 2>/dev/null)
+if [[ "$_uuid" != "$_uuid2" ]]; then
+    assert_pass "new_uuid is unique per call"
+else
+    assert_fail "new_uuid is unique per call"
+fi
+
 # ─── Test 12: Token accumulation parses JSON ────────────────────────────────
 if grep -q 'jq.*usage.input_tokens' "$SCRIPT_DIR/sw-loop.sh"; then
     assert_pass "accumulate_loop_tokens parses JSON usage"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -129,6 +129,25 @@ CONTEXT_EXHAUSTION_PATTERNS="context.length.exceeded|maximum context length|cont
 CONTEXT_RESTART_COUNT=0
 CONTEXT_RESTART_LIMIT=$(_smart_int "loop.context_restart_limit" 2)
 
+# ─── Session Continuity ──────────────────────────────────────────────────────
+# Each iteration currently starts a COLD Claude session: the prompt is
+# recomposed from scratch and the cache is written again rather than read.
+# Passing one --session-id across iterations lets them continue a single
+# conversation instead.
+#
+# Off by default. This changes conversation semantics — the model carries prior
+# turns rather than being re-briefed from progress.md — so it wants a measured
+# rollout (compare `shipwright cost show` with it on and off) rather than being
+# switched on for every existing pipeline at once. Enable with
+# `--session-continuity`, LOOP_SESSION_CONTINUITY=1, or loop.session_continuity
+# in config.
+#
+# LOOP_SESSION_ID stays EMPTY when disabled; build_claude_flags keys off that,
+# so the flag is simply absent in the default path.
+SESSION_CONTINUITY="${LOOP_SESSION_CONTINUITY:-$(_config_get_int "loop.session_continuity" 0 2>/dev/null || echo 0)}"
+[[ "$SESSION_CONTINUITY" == "true" ]] && SESSION_CONTINUITY=1
+LOOP_SESSION_ID=""
+
 # ─── Audit & Quality Gate Defaults ───────────────────────────────────────────
 AUDIT_ENABLED=false
 AUDIT_AGENT_ENABLED=false
@@ -266,6 +285,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --max-turns=*) MAX_TURNS="${1#--max-turns=}"; shift ;;
         --resume) RESUME=true; shift ;;
+        # NOTE: --resume above is shipwright's own (re-read .claude/loop-state.md).
+        # This is different: it continues one *Claude* session across iterations.
+        --session-continuity) SESSION_CONTINUITY=1; shift ;;
+        --no-session-continuity) SESSION_CONTINUITY=0; shift ;;
         --verbose) VERBOSE=true; shift ;;
         --audit) AUDIT_ENABLED=true; shift ;;
         --audit-agent) AUDIT_AGENT_ENABLED=true; shift ;;
@@ -2115,6 +2138,21 @@ run_single_agent_loop() {
     # Save original environment variables before loop starts
     local SAVED_CLAUDE_MODEL="${CLAUDE_MODEL:-}"
     local SAVED_ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
+
+    # One session ID per invocation of this function, so the iterations inside
+    # it continue a single conversation instead of cold-starting each time.
+    #
+    # run_loop_with_restarts re-enters this function for every restart, so a
+    # deliberate restart naturally gets a NEW id. That is required, not
+    # incidental: context-exhaustion recovery is *supposed* to drop the old
+    # context and re-orient from progress.md, and reusing the id would defeat
+    # the very thing the restart exists to do.
+    if [[ "${SESSION_CONTINUITY:-0}" == "1" ]]; then
+        LOOP_SESSION_ID=$(new_uuid)
+        info "Session continuity enabled (session ${LOOP_SESSION_ID})"
+    else
+        LOOP_SESSION_ID=""
+    fi
 
     if [[ "$SESSION_RESTART" == "true" ]]; then
         # Restart: state already reset by run_loop_with_restarts, skip init


### PR DESCRIPTION
Two cost levers on the same underlying problem, following #815.

The build loop shelled out to a fresh `claude -p` per iteration — prompt recomposed from scratch, cache written rather than read, nothing carried forward. Shipwright passes **6 of the CLI's ~50 flags**, and neither of these was among them.

## 1. Prompt-cache prefix stability — **on by default**

Passes `--exclude-dynamic-system-prompt-sections`, moving per-machine sections (cwd, env info, memory paths, and **git status**) out of the system prompt into the first user message.

Prompt caching is a **prefix match**. Git status changes constantly during a build loop, so leaving it at the front of the prefix invalidated everything after it on essentially every iteration. Behavior is unchanged — only where the content sits. Opt out with `LOOP_STABLE_PROMPT_PREFIX=false`.

The CLI ignores this flag when a custom `--system-prompt` is supplied; verified this loop passes none.

## 2. Session continuity — **off by default**

Generates one UUID per run and passes `--session-id`, so iterations continue a single conversation.

Off by default deliberately: it changes semantics — the model carries prior turns instead of being re-briefed from `progress.md` — so it deserves a measured rollout rather than being switched on under every existing pipeline at once. Enable with `--session-continuity`, `LOOP_SESSION_CONTINUITY=1`, or `loop.session_continuity`.

**Restart interaction:** `run_loop_with_restarts` re-enters `run_single_agent_loop` per restart, so a deliberate restart allocates a **new** id. That's required, not incidental — context-exhaustion recovery exists to drop stale context and re-orient from `progress.md`, and reusing the id would defeat the thing the restart is for.

Note `shipwright loop --resume` is unrelated (it re-reads `.claude/loop-state.md`); the naming collision is why the new flag is spelled `--session-continuity`.

## Testing

The six new assertions **invoke `build_claude_flags` and check what it emits**, rather than grepping the source for a flag name as the neighbouring tests do. A grep passes even when the flag never reaches the command line — which is precisely the failure worth guarding against.

```
✓ stable prompt prefix is on by default
✓ stable prompt prefix can be disabled
✓ no --session-id when continuity is off
✓ --session-id passed through when continuity is on
✓ new_uuid emits a valid UUID
✓ new_uuid is unique per call
```

`sw-loop-test`: **74 passed** (was 68). CI's exact shellcheck invocation: clean.

Also adds `new_uuid` to `compat.sh` (uuidgen → `/proc/sys/kernel/random/uuid` → awk fallback), since `--session-id` must be a valid UUID and `uuidgen` isn't guaranteed present.

## What is NOT verified

**No real `claude` invocation was possible** — the account is at its weekly usage limit until Jul 30. Flag construction is proven; the runtime effect on cache hit rate is not. That's the second reason continuity ships off: measure with `shipwright cost show` on and off before enabling it broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)